### PR TITLE
Add filtering options `base` and `ignore`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea/
 node_modules
 *.log

--- a/index.js
+++ b/index.js
@@ -37,12 +37,12 @@ function gulpFileNamesToJson(options) {
             if (Array.isArray(options.ignore)) {
                 options.ignore.forEach(
                     function(pattern) {
-                        if (fileName.test(pattern)) {
+                        if (fileName.match(pattern)) {
                             ignore = true;
                         }
                     });
             } else if (options.ignore instanceof RegExp || typeof options.ignore === 'string') {
-                if (fileName.test(options.ignore)) {
+                if (fileName.match(options.ignore)) {
                     ignore = true;
                 }
             }

--- a/index.js
+++ b/index.js
@@ -37,12 +37,12 @@ function gulpFileNamesToJson(options) {
             if (Array.isArray(options.ignore)) {
                 options.ignore.forEach(
                     function(pattern) {
-                        if (fileName.match(pattern)) {
+                        if (fileName.test(pattern)) {
                             ignore = true;
                         }
                     });
             } else if (options.ignore instanceof RegExp || typeof options.ignore === 'string') {
-                if (fileName.match(options.ignore)) {
+                if (fileName.test(options.ignore)) {
                     ignore = true;
                 }
             }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "gulpplugin"
   ],
   "dependencies": {
+    "escape-string-regexp": "^1.0.5",
     "gulp-util": "^3.0.4",
     "slash": "^1.0.0",
     "through2": "^0.6.5"

--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,19 @@ Default: `files.json`
 
 The file name of the generated JSON document.
 
+##### base
+
+Type: `string`  
+Default: ``
+
+String to remove from left side of filename. e.g. providing `dist` to a match of `dist/file` would return `/file`.
+
+##### ignore
+
+Type: `string` or `Array`  
+Default: ``
+
+Filter regex string or array of  regex strings. If a filename matches, it will be ignored. 
 
 ## License
 


### PR DESCRIPTION
Adds two features:

1: base: allows removing part of the path before outputting the file list. This is useful if you want to remove the destination directory.

2: ignore: allows files to be ignored based with regex matching.
