### PR TITLE
Allow the user to set full path or just file name in the output

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,11 @@ function gulpFilenamesToJson(options) {
             this.files = [];
         }
 
-        this.files.push(slash(path.relative(file.cwd, file.path)));
+        if (options.fullPath === false) {
+            this.files.push(path.parse(file.path).base);
+        } else {
+            this.files.push(slash(path.relative(file.cwd, file.path)));
+        }
 
         cb();
     }


### PR DESCRIPTION
This came from a project I was working on.  For simplicity, I only wanted the filename output instead of the full path.  Now the user can add the option "fullPath: false" to save only the filename to the output json file.  Let me know what you think.  Thanks!