### PR TITLE
Adding cwd option

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,11 +19,13 @@ function gulpFilenamesToJson(options) {
     }
 
     function combine(file, enc, cb) {
+        var cwd = options.cwd || file.cwd;
+
         if (typeof(this.files) === 'undefined') {
             this.files = [];
         }
 
-        this.files.push(slash(path.relative(file.cwd, file.path)));
+        this.files.push(slash(path.relative(cwd, file.path)));
 
         cb();
     }
@@ -31,7 +33,7 @@ function gulpFilenamesToJson(options) {
     function flush(cb) {
         var file = new gutil.File({
             cwd: '',
-            base: '',
+            base: 'app/',
             path: path.join(options.fileName),
             contents: new Buffer(JSON.stringify(this.files))
         });

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ function gulpFilenamesToJson(options) {
     function flush(cb) {
         var file = new gutil.File({
             cwd: '',
-            base: 'app/',
+            base: '',
             path: path.join(options.fileName),
             contents: new Buffer(JSON.stringify(this.files))
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-filenames-to-json",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Simple gulp plugin that creates a JSON file containing the relative filenames of all piped files as an array.",
   "license": "MIT",
   "repository": "olohmann/gulp-filenames-to-json",

--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,28 @@ Default: `files.json`
 
 The file name of the generated JSON document.
 
+##### cwd
+
+Type: `string`
+Default: [original, full file path]
+
+Portion of file paths to be excluded in the JSON
+
+```js
+gulp.task('default', function () {
+    return gulp.src('./app/js/**/*.js')
+        .pipe(filenamesToJson({
+            cwd: 'app/'    
+        }))
+        .pipe(gulp.dest('.'));
+    
+    // --> 
+    // transforms
+    // ["app/js/fileA.js","app/js/fileB.js"]
+    // to
+    // ["js/fileA.js","js/fileB.js"]
+});
+```
 
 ## License
 


### PR DESCRIPTION
## Need

Our project builds a list of files for a service worker to cache.

## Issue

The service worker lives in the same app-root directory as the cache files, but this module creates relative paths from the gulpfile.

## Solve

Adding a `cwd` option allows the user to say if they want portions of the file names to be excluded.